### PR TITLE
feat(vaults): replace VA monogram with numeric vault index and centra…

### DIFF
--- a/app/components/discover/PendingRequestCard.tsx
+++ b/app/components/discover/PendingRequestCard.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/app/components/ui/Card";
 import { Badge } from "@/app/components/ui/Badge";
 import { LabelValue } from "@/app/components/ui/LabelValue";
 import { CopyButton } from "@/app/components/ui/CopyButton";
+import { VaultIcon } from "@/app/components/vaults/VaultIcon";
 import Link from "next/link";
 import Big from "big.js";
 import { formatMinimalTokenAmount } from "@/utils/format";
@@ -117,15 +118,13 @@ export function PendingRequestCard({ item, factoryId }: Props) {
     }
   };
 
-  const initials = (id: string) => (id.split(".")[0] || id).slice(0, 2).toUpperCase();
+  
 
   return (
     <Card className="p-3">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0">
-          <div aria-hidden className="h-9 w-9 shrink-0 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-medium">
-            {initials(item.id)}
-          </div>
+          <VaultIcon id={item.id} size="md" />
           <div className="min-w-0">
             <div className="font-medium truncate" title={item.id}>
               {item.id}

--- a/app/components/vaults/VaultIcon.tsx
+++ b/app/components/vaults/VaultIcon.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React from "react";
+
+type Props = {
+  id: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  title?: string;
+};
+
+function labelFromVaultId(id: string): string {
+  const base = (id.split(".")[0] || id);
+  const m = base.match(/vault-(\d+)/i);
+  if (m) return m[1];
+  const alt = base.match(/(\d+)/);
+  if (alt) return alt[1];
+  return base.slice(0, 2).toUpperCase();
+}
+
+export function VaultIcon({ id, size = "md", className = "", title }: Props) {
+  const sizeClass = size === "sm" ? "h-8 w-8" : size === "lg" ? "h-10 w-10" : "h-9 w-9";
+  const baseClass = "shrink-0 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-medium";
+  return (
+    <div
+      aria-hidden
+      className={`${sizeClass} ${baseClass} ${className}`.trim()}
+      title={title ?? id}
+    >
+      {labelFromVaultId(id)}
+    </div>
+  );
+}
+

--- a/app/components/vaults/VaultList.tsx
+++ b/app/components/vaults/VaultList.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/app/components/ui/Badge";
 import { Card } from "@/app/components/ui/Card";
 import { CopyButton } from "@/app/components/ui/CopyButton";
 import { useState } from "react";
+import { VaultIcon } from "@/app/components/vaults/VaultIcon";
 
 export type VaultSummary = { id: string; state: "idle" | "pending" | "active" };
 export type VaultListProps = {
@@ -17,11 +18,7 @@ export type VaultListProps = {
 export function VaultList({ vaultIds, onVaultClick, summaries }: VaultListProps) {
   const [copied] = useState<string | null>(null);
 
-  const initials = (id: string) => {
-    // Use first two visible characters before a dot if possible
-    const base = id.split(".")[0] || id;
-    return base.slice(0, 2).toUpperCase();
-  };
+  
 
   const stateFor = (id: string): VaultSummary["state"] | undefined => {
     const s = summaries?.find((v) => v.id === id)?.state;
@@ -38,12 +35,7 @@ export function VaultList({ vaultIds, onVaultClick, summaries }: VaultListProps)
   const ItemInner = ({ id }: { id: string }) => (
     <Card className="flex items-center justify-between gap-3 hover:bg-background/70">
       <div className="flex items-center gap-3 min-w-0">
-        <div
-          aria-hidden
-          className="h-8 w-8 shrink-0 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-medium"
-        >
-          {initials(id)}
-        </div>
+        <VaultIcon id={id} size="sm" />
         <div className="min-w-0">
           <div className="font-medium truncate" title={id}>
             {id}


### PR DESCRIPTION
…lize as VaultIcon component

- Add reusable app/components/vaults/VaultIcon.tsx (parses vault-<index>, falls back to digits or initials)
- Refactor PendingRequestCard and VaultList to use VaultIcon
- Ensures consistent display of vault numbers across UI

Closes #75 