### PR TITLE
Enhance discover requests UI and filter experience

### DIFF
--- a/app/components/discover/PendingFilters.tsx
+++ b/app/components/discover/PendingFilters.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { Input } from "@/app/components/ui/Input";
 import { Select } from "@/app/components/ui/Select";
-import { getKnownTokens } from "@/utils/tokens";
+import { getKnownTokens, getTokenConfigById } from "@/utils/tokens";
 import { getActiveNetwork } from "@/utils/networks";
 
 export type PendingFilters = {
@@ -17,22 +17,28 @@ export type PendingFilters = {
 export function PendingFilters({ value, onChange }: { value: PendingFilters; onChange: (v: PendingFilters) => void }) {
   const network = getActiveNetwork();
   const tokens = getKnownTokens(network);
+  const selectedSymbol = value.token ? (getTokenConfigById(value.token, network)?.symbol ?? undefined) : undefined;
 
   const set = (patch: Partial<PendingFilters>) => onChange({ ...value, ...patch });
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+    <div className="grid grid-cols-1 sm:grid-cols-12 gap-2">
       <Input
         label="Search"
-        placeholder="Vault or owner"
+        placeholder="Vault or owner (e.g. name.near)"
         value={value.q}
         onChange={(e) => set({ q: e.target.value })}
         className="h-9"
+        containerClassName="sm:col-span-12"
+        type="search"
+        autoComplete="off"
+        spellCheck={false}
       />
       <Select
         label="Token"
         value={value.token ?? ""}
         onChange={(e) => set({ token: (e.target as HTMLSelectElement).value || null })}
+        containerClassName="sm:col-span-6 md:col-span-3"
       >
         <option value="">All</option>
         {tokens.map((t) => (
@@ -47,7 +53,8 @@ export function PendingFilters({ value, onChange }: { value: PendingFilters; onC
         value={value.minAmount}
         onChange={(e) => set({ minAmount: e.target.value })}
         className="h-9"
-        hint="Token display units"
+        containerClassName="sm:col-span-6 md:col-span-3"
+        suffix={selectedSymbol}
       />
       <Input
         label="Max term (days)"
@@ -57,12 +64,13 @@ export function PendingFilters({ value, onChange }: { value: PendingFilters; onC
         value={value.maxDays}
         onChange={(e) => set({ maxDays: e.target.value })}
         className="h-9"
+        containerClassName="sm:col-span-6 md:col-span-3"
       />
       <Select
         label="Sort"
-        className="sm:col-span-2"
         value={value.sort}
         onChange={(e) => set({ sort: (e.target as HTMLSelectElement).value as PendingFilters["sort"] })}
+        containerClassName="sm:col-span-6 md:col-span-3"
       >
         <option value="updated_desc">Newest</option>
         <option value="amount_desc">Amount (desc)</option>

--- a/app/components/discover/PendingRequestCard.tsx
+++ b/app/components/discover/PendingRequestCard.tsx
@@ -9,7 +9,7 @@ import { VaultIcon } from "@/app/components/vaults/VaultIcon";
 import Link from "next/link";
 import Big from "big.js";
 import { formatMinimalTokenAmount } from "@/utils/format";
-import { getTokenConfigById, getTokenDecimals } from "@/utils/tokens";
+import { getTokenConfigById } from "@/utils/tokens";
 import { networkFromFactoryId } from "@/utils/api/rpcClient";
 import { AcceptLiquidityConfirm } from "@/app/components/dialogs/AcceptLiquidityConfirm";
 import { useAcceptLiquidityRequest } from "@/hooks/useAcceptLiquidityRequest";
@@ -45,14 +45,8 @@ export function PendingRequestCard({ item, factoryId }: Props) {
   const repayLabel = useMemo(() => {
     try {
       if (!lr) return "—";
-      const amount = new Big(lr.amount);
-      const interest = new Big(lr.interest);
-      const total = amount.plus(interest);
-      const display = total.div(new Big(10).pow(decimals));
-      // Reuse formatMinimalTokenAmount behavior via toFixed-like truncation
-      // Keep 2-6 decimals depending on magnitude
-      const s = display.lt(1) ? display.toFixed(6) : display.lt(1000) ? display.toFixed(3) : display.round(2, 0).toString();
-      return s.replace(/\.0+$/, "");
+      const totalRaw = new Big(lr.amount).plus(new Big(lr.interest)).toFixed(0);
+      return formatMinimalTokenAmount(totalRaw, decimals);
     } catch { return "—"; }
   }, [lr, decimals]);
   const collateralNear = useMemo(() => (lr ? safeFormatYoctoNear(lr.collateral, 5) : "—"), [lr]);

--- a/app/components/discover/PendingRequestCard.tsx
+++ b/app/components/discover/PendingRequestCard.tsx
@@ -42,6 +42,19 @@ export function PendingRequestCard({ item, factoryId }: Props) {
 
   const amountLabel = useMemo(() => (lr ? formatMinimalTokenAmount(lr.amount, decimals) : "—"), [lr, decimals]);
   const interestLabel = useMemo(() => (lr ? formatMinimalTokenAmount(lr.interest, decimals) : "—"), [lr, decimals]);
+  const repayLabel = useMemo(() => {
+    try {
+      if (!lr) return "—";
+      const amount = new Big(lr.amount);
+      const interest = new Big(lr.interest);
+      const total = amount.plus(interest);
+      const display = total.div(new Big(10).pow(decimals));
+      // Reuse formatMinimalTokenAmount behavior via toFixed-like truncation
+      // Keep 2-6 decimals depending on magnitude
+      const s = display.lt(1) ? display.toFixed(6) : display.lt(1000) ? display.toFixed(3) : display.round(2, 0).toString();
+      return s.replace(/\.0+$/, "");
+    } catch { return "—"; }
+  }, [lr, decimals]);
   const collateralNear = useMemo(() => (lr ? safeFormatYoctoNear(lr.collateral, 5) : "—"), [lr]);
 
   const aprLabel = useMemo(() => {
@@ -121,7 +134,7 @@ export function PendingRequestCard({ item, factoryId }: Props) {
   
 
   return (
-    <Card className="p-3">
+    <Card className="p-3 hover:border-foreground/20 transition-colors">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0">
           <VaultIcon id={item.id} size="md" />
@@ -144,9 +157,10 @@ export function PendingRequestCard({ item, factoryId }: Props) {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 mt-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2 mt-3">
         <LabelValue label="Amount" value={`${amountLabel} ${symbol}`} />
         <LabelValue label="Interest" value={`${interestLabel} ${symbol}`} />
+        <LabelValue label="Repay" value={`${repayLabel} ${symbol}`} />
         <LabelValue label="Term" value={formatDurationFromSeconds(durationSeconds)} />
         <LabelValue label="Collateral" value={`${collateralNear} NEAR`} />
         <LabelValue label="Est. APR" value={aprLabel} />

--- a/app/components/discover/PendingRequestsList.tsx
+++ b/app/components/discover/PendingRequestsList.tsx
@@ -29,8 +29,9 @@ export function PendingRequestsList({ factoryId }: { factoryId: string }) {
     if (!sentinel) return;
     const rootStyles = getComputedStyle(document.documentElement);
     const navVar = rootStyles.getPropertyValue("--nav-height").trim();
-    const navPx = navVar.endsWith("px") ? Number(navVar.replace("px", "")) : Number(navVar || 56);
-    const rootMargin = `-${isNaN(navPx) ? 56 : navPx}px 0px 0px 0px`;
+    const parsed = parseInt(navVar, 10);
+    const navPx = Number.isFinite(parsed) ? parsed : 56;
+    const rootMargin = `-${navPx}px 0px 0px 0px`;
     const io = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];

--- a/app/components/ui/Input.tsx
+++ b/app/components/ui/Input.tsx
@@ -6,6 +6,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   label?: string;
   hint?: string;
   containerClassName?: string;
+  suffix?: React.ReactNode;
 };
 
 export function Input({
@@ -13,16 +14,27 @@ export function Input({
   hint,
   containerClassName = "",
   className = "",
+  suffix,
   ...rest
 }: InputProps) {
-  const inputBase =
-    "w-full rounded border bg-background p-2 outline-none focus:ring-2 focus:ring-primary/50";
+  const hasSuffix = Boolean(suffix);
+  const inputBase = [
+    "w-full rounded border bg-background p-2",
+    hasSuffix ? "pr-9" : "",
+    "outline-none focus:ring-2 focus:ring-primary/50",
+  ].join(" ");
   return (
     <label className={`block text-sm ${containerClassName}`}>
       {label && <span className="text-secondary-text">{label}</span>}
-      <input className={`mt-1 ${inputBase} ${className}`} {...rest} />
+      <div className="relative mt-1">
+        <input className={`${inputBase} ${className}`} {...rest} />
+        {hasSuffix && (
+          <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-secondary-text">
+            {suffix}
+          </div>
+        )}
+      </div>
       {hint && <div className="mt-1 text-xs text-secondary-text">{hint}</div>}
     </label>
   );
 }
-

--- a/app/components/ui/Select.tsx
+++ b/app/components/ui/Select.tsx
@@ -8,6 +8,24 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
   containerClassName?: string;
 };
 
+function ChevronDownIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className="w-4 h-4"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.085l3.71-3.855a.75.75 0 1 1 1.08 1.04l-4.24 4.41a.75.75 0 0 1-1.08 0L5.25 8.27a.75.75 0 0 1-.02-1.06Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export function Select({
   label,
   hint,
@@ -16,15 +34,26 @@ export function Select({
   children,
   ...rest
 }: SelectProps) {
-  const base = "w-full rounded border bg-background p-2 h-9 outline-none focus:ring-2 focus:ring-primary/50";
+  const base = [
+    "w-full rounded border bg-background text-foreground",
+    "h-9 px-2 pr-8",
+    "appearance-none",
+    "outline-none focus:ring-2 focus:ring-primary/50",
+    "disabled:opacity-60 disabled:cursor-not-allowed",
+  ].join(" ");
+
   return (
     <label className={`block text-sm ${containerClassName}`}>
       {label && <span className="text-secondary-text">{label}</span>}
-      <select className={`mt-1 ${base} ${className}`} {...rest}>
-        {children}
-      </select>
+      <div className="relative mt-1">
+        <select className={`${base} ${className}`} {...rest}>
+          {children}
+        </select>
+        <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-secondary-text">
+          <ChevronDownIcon />
+        </div>
+      </div>
       {hint && <div className="mt-1 text-xs text-secondary-text">{hint}</div>}
     </label>
   );
 }
-

--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -7,7 +7,7 @@ import { PendingRequestsList } from "@/app/components/discover/PendingRequestsLi
 export default function DiscoverPage() {
   const factoryId = getActiveFactoryId();
   return (
-    <div className="min-h-screen p-8 pb-20 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="min-h-screen pb-20 font-[family-name:var(--font-geist-sans)]">
       <main id="main" className="w-full max-w-2xl mx-auto">
         <PendingRequestsList factoryId={factoryId} />
       </main>


### PR DESCRIPTION
Improves the discover requests page with a sticky header, filter state persistence, filter chips for active filters, and a more responsive layout. Adds a 'Repay' column to request cards, improves input and select components with suffixes and icons, and refines loading and empty states. These changes enhance usability, accessibility, and visual clarity for users browsing and filtering pending requests.

Closes #82 